### PR TITLE
std::tring & char* refactor

### DIFF
--- a/seastar/flusher.cc
+++ b/seastar/flusher.cc
@@ -314,7 +314,8 @@ future<bool> Flusher::storeEncodedAgg(uint64_t vol_id, uint8_t *hash, int hash_l
 
 	for (int i=0; i < _k; i++) {
 		auto rc = _redis_conns[i+1];
-		rc->set(hash, hash_len, data[i], chunksize).then([this, finished,i,&vr] (auto ok){
+		rc->set((const char *)hash, hash_len, 
+				(const char *)data[i], chunksize).then([this, finished,i,&vr] (auto ok){
 				vr[i+1] = ok;
 				}).finally([finished] {
 					finished->signal();
@@ -324,7 +325,8 @@ future<bool> Flusher::storeEncodedAgg(uint64_t vol_id, uint8_t *hash, int hash_l
 	// store the coded data
 	for (int i=0; i < _m; i++) {
 		auto rc = _redis_conns[i + 1 + _k];
-		rc->set(hash, hash_len, coding[i], chunksize).then([this, finished, i, &vr] (auto ok){
+		rc->set((const char *)hash, hash_len, 
+				(const char *)coding[i], chunksize).then([this, finished, i, &vr] (auto ok){
 				vr[i + 1 + _k] = ok;
 			}).finally([finished] {
 				finished->signal();
@@ -336,8 +338,8 @@ future<bool> Flusher::storeEncodedAgg(uint64_t vol_id, uint8_t *hash, int hash_l
 	
 	auto rc = _redis_conns[0];
 	
-	rc->set((uint8_t *) last.c_str(), last.length(), 
-			(unsigned char *) hash, hash_len).then([this, finished, &vr] (auto ok){
+	rc->set(last.c_str(), last.length(), 
+			(const char *) hash, hash_len).then([this, finished, &vr] (auto ok){
 				vr[0] = ok;
 			}).finally([finished] {
 				finished->signal();

--- a/seastar/flusher.h
+++ b/seastar/flusher.h
@@ -156,8 +156,8 @@ private:
 
 	bool ok_to_flush(uint32_t vol_id, int flush_size);
 
-	future<bool> storeEncodedAgg(uint64_t vol_id, uint8_t *hash, int hash_len,
-			unsigned char **data, unsigned char **coding, int chunksize);
+	future<bool> storeEncodedAgg(uint64_t vol_id, const char *hash, int hash_len,
+			const char **data, const char **coding, int chunksize);
 
 	uint8_t* hash_gen(uint64_t vol_id, uint8_t *data, uint8_t data_len,
 			uint8_t *key, int key_len);

--- a/seastar/redis_conn.h
+++ b/seastar/redis_conn.h
@@ -12,8 +12,8 @@ private:
 	input_stream<char> _in;
 public:
 	redis_conn(connected_socket&& fd);
-	future<bool> set(std::string key, std::string val);
-	future<bool> set(const uint8_t *key, int key_len, const uint8_t *val, int val_len);
+	future<bool> set(const std::string& key, const std::string& val);
+	future<bool> set(const char *key, int key_len, const char *val, int val_len);
 };
 
 #endif


### PR DESCRIPTION
Closes #50 

From what i've read, std::string wont give performance penalty if we use it **correctly**. It will improve readability for sure.

Considering our small code base, readability is not an issue while any performance penalty must be avoided.

So, this PR doesn't change `char *` to `std::string`, it only do code cleanup and std::string usage optimization.