### PR TITLE
seastar : Tlog block optimization

### DIFF
--- a/client/examples/client.go
+++ b/client/examples/client.go
@@ -20,7 +20,7 @@ func main() {
 
 	flag.Parse()
 
-	volID := "1234567890"
+	volID := "12345678901234567890123456789012"
 
 	clients := make([]*client.Client, numClient)
 	clientReady := make(chan int, numClient)

--- a/client/tlog_schema.capnp.go
+++ b/client/tlog_schema.capnp.go
@@ -214,12 +214,12 @@ type TlogAggregation struct{ capnp.Struct }
 const TlogAggregation_TypeID = 0xe46ab5b4b619e094
 
 func NewTlogAggregation(s *capnp.Segment) (TlogAggregation, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 24, PointerCount: 3})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 16, PointerCount: 4})
 	return TlogAggregation{st}, err
 }
 
 func NewRootTlogAggregation(s *capnp.Segment) (TlogAggregation, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 24, PointerCount: 3})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 16, PointerCount: 4})
 	return TlogAggregation{st}, err
 }
 
@@ -268,26 +268,37 @@ func (s TlogAggregation) SetTimestamp(v uint64) {
 	s.Struct.SetUint64(8, v)
 }
 
-func (s TlogAggregation) VolumeId() uint32 {
-	return s.Struct.Uint32(16)
-}
-
-func (s TlogAggregation) SetVolumeId(v uint32) {
-	s.Struct.SetUint32(16, v)
-}
-
-func (s TlogAggregation) Blocks() (TlogBlock_List, error) {
+func (s TlogAggregation) VolumeId() (string, error) {
 	p, err := s.Struct.Ptr(1)
-	return TlogBlock_List{List: p.List()}, err
+	return p.Text(), err
 }
 
-func (s TlogAggregation) HasBlocks() bool {
+func (s TlogAggregation) HasVolumeId() bool {
 	p, err := s.Struct.Ptr(1)
 	return p.IsValid() || err != nil
 }
 
+func (s TlogAggregation) VolumeIdBytes() ([]byte, error) {
+	p, err := s.Struct.Ptr(1)
+	return p.TextBytes(), err
+}
+
+func (s TlogAggregation) SetVolumeId(v string) error {
+	return s.Struct.SetText(1, v)
+}
+
+func (s TlogAggregation) Blocks() (TlogBlock_List, error) {
+	p, err := s.Struct.Ptr(2)
+	return TlogBlock_List{List: p.List()}, err
+}
+
+func (s TlogAggregation) HasBlocks() bool {
+	p, err := s.Struct.Ptr(2)
+	return p.IsValid() || err != nil
+}
+
 func (s TlogAggregation) SetBlocks(v TlogBlock_List) error {
-	return s.Struct.SetPtr(1, v.List.ToPtr())
+	return s.Struct.SetPtr(2, v.List.ToPtr())
 }
 
 // NewBlocks sets the blocks field to a newly
@@ -297,22 +308,22 @@ func (s TlogAggregation) NewBlocks(n int32) (TlogBlock_List, error) {
 	if err != nil {
 		return TlogBlock_List{}, err
 	}
-	err = s.Struct.SetPtr(1, l.List.ToPtr())
+	err = s.Struct.SetPtr(2, l.List.ToPtr())
 	return l, err
 }
 
 func (s TlogAggregation) Prev() ([]byte, error) {
-	p, err := s.Struct.Ptr(2)
+	p, err := s.Struct.Ptr(3)
 	return []byte(p.Data()), err
 }
 
 func (s TlogAggregation) HasPrev() bool {
-	p, err := s.Struct.Ptr(2)
+	p, err := s.Struct.Ptr(3)
 	return p.IsValid() || err != nil
 }
 
 func (s TlogAggregation) SetPrev(v []byte) error {
-	return s.Struct.SetData(2, v)
+	return s.Struct.SetData(3, v)
 }
 
 // TlogAggregation_List is a list of TlogAggregation.
@@ -320,7 +331,7 @@ type TlogAggregation_List struct{ capnp.List }
 
 // NewTlogAggregation creates a new list of TlogAggregation.
 func NewTlogAggregation_List(s *capnp.Segment, sz int32) (TlogAggregation_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 24, PointerCount: 3}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 16, PointerCount: 4}, sz)
 	return TlogAggregation_List{l}, err
 }
 
@@ -338,41 +349,41 @@ func (p TlogAggregation_Promise) Struct() (TlogAggregation, error) {
 	return TlogAggregation{s}, err
 }
 
-const schema_f4533cbae6e08506 = "x\xdat\x93OH\x15_\x1c\xc5\xcf\xf9\xde7\xef)" +
-	"\xa8\xef7\xbeY\xfc\x0a#\x08[(\x19\xfe\xd9\x89a" +
-	"\xb6\xaaV^\x0dZ\xc68^^\xe6\xbc7/g\xb4" +
+const schema_f4533cbae6e08506 = "x\xdat\x93OHT_\x1c\xc5\xcf\xf9\xde\xf7f\x14" +
+	"\xd4\xf9=g\x16\xbf\xc2\x08\xc2\x16J\x86\x7fvb\x98" +
+	"\xad\xaa\x95W\x83\x96\xf1|^&\xf3\xcd\xbc\xc9\xf7\xb4" +
 	"h\x19\xb4\x89\xa0\x8d\x0b[\x04\x06-\x0a\xdc\x04\x1a\x14" +
-	"\x05\x06I\x06\x06\x09\x06\xb5\x09\x8bh\x1f\xb4j3q" +
-	"\xd5\xf7\xde\x04\xb5\xbbs8w\xce\xf7{>\xdc\xfeI" +
-	"\x9e\x96\x01'\x12@w9\xf9t`\xe7\xe6\xc8\xe7\xeb" +
-	"?\xee@w2\x97\xe6o\xed~\x7f>2\xf9\x13\x8e" +
-	"\x14\x80\xd2\x11~-\xf5\xb0\x00\x0c\x1d\xe7]\x82\xe9\xa7" +
-	"\xee\xdbo\xbe\x1c\xde^\xb2nf\xdc\xd6Sz&\xbf" +
-	"J\x1b{\xf7^\xc950]\xdc=\xf4tu\xed\xca" +
-	"7kV\x19\xb3\xb2?\x1cP\x9d,\x8d\xed\x1dO\xa9" +
-	"\x8bD_\x9a\x84Q\xf9R\x1c\\\x16S\xf1O\x06~" +
-	"\xadZ\x1b\xbe\x10F\xe53a!\x0af\xc7I\xdd\xa5" +
-	"r@\x8e\x80\xbbv\x1e\xd0\xab\x8az]Hz\xb4\xda" +
-	"K\xab\xbdP\xd4\x9bBW\xe8Q\x00w\xe3\x18\xa0\xd7" +
-	"\x15\xf5\x96\xd0U9\x8f\x0ap\xdf\xf6\x02\xfa\xb5\xa2~" +
-	"/ts\x8e\xc7\x1c\xe0\xbe\x1b\x04\xf4\xa6\xa2\xde\x11\xba" +
-	"\x0e=:\x80\xbbm\x9d[\x8a\xfa\xa3\xd0\xcd+\x8fy" +
-	"\xc0\xfd0\x01\xe8\x1dE\xbd+L\x17\xa2p\xbeb\xce" +
-	"M\x03`\x1b\x84m`\x1a\x9b\xab\xf3\xa6\x1a\x18\xab\xb5" +
-	"B\xd8\x0a\x16\xc2)\xbf~.\xc637\x0c[ l" +
-	"\x01\x8f\x06s\xc1\xd0`\xfd\xab8\xed'>\xdb!l" +
-	"\x07\xd3d\xa6b\xe2\xc4\xaf\x80\xb5\xfa\xdd\x7f\x954a" +
-	"F\xe3ZT\x8d\x8d\xed\xa9\xa5\xd1S\xcf0\xa0\xbb\x15" +
-	"u\x7f\xb3\xa7>;\xfe\x09E}V8\x1a'~2" +
-	"\x1fS \x94\xec\xe4\x8c\xd9\x01\x8e+\xee\x05wd\x82" +
-	"\xd5\x9f\xc1c\xe5\xf2\x9c)\xfb\xc9L\xc4\xaa\xcd\xfe\xbf" +
-	"\x91}\xcfv\xb7\xa8\xa8\x97\x9b\xd9\xf7\xad\xb6\xa4\xa8\x1f" +
-	"f\x18=\xb0\x03-+\xea\x95\x0c\xa3\xc7\x96\xe6#E" +
-	"\xbdj\x19q\x9f\xd1\x13\xbb\xce\xca\x01bG\xf6\x19m" +
-	"\xf46\x11\x17\xab~\xc5\xd49\xec\xf7\xdc(\xee/e" +
-	"f\xe1\x1d\x10\x18\x9d\x0a\xa3`\xb6\xb1\xfd\x7f\xcd\xf7\x01" +
-	"Z\xb1X\x9b3\x0buB\xbf\x03\x00\x00\xff\xffI\xe2" +
-	"\xb8\x8e"
+	"\x05\x06I\x06\x06\x09\x06\xb5\x89)\xa2}\xd0\xaa\xcd\x8b" +
+	"\xeb4\x7f\x02\xdb\xddw8\xf7\x9d\xef\xf7|\xb8\x83\xd3" +
+	"<-Cn$\x80\xeeq3\xe9\xd0\xde\xcd\xb1\xcf\xd7" +
+	"\x7f\xdc\x81\xee\xa6\x93fnU\xbf?\x1f\x9b\xfe\x09W" +
+	"\xb2@\xfe\x08\xbf\xe6\xfb\x98\x05F\x8e\xf3.\xc1\xf4S" +
+	"\xef\xed7_\x0e\xef\xaeX7[\xdc\xd6\x93\x7f&\xbf" +
+	"\xf2[\xfb\xf7^\xc950]\xae\x1ez\xba\xbeq\xe5" +
+	"\x9b5K\x8b\xd9\xb1?\x1cR\xdd\xccO({<\xa5" +
+	".\x12\x03i\x12F\xc5KqpYL\xc9?\x19\xf8" +
+	"\x95re\xf4B\x18\x15\xcf\x84\xd9(\x98\x9f$u\x8f" +
+	"r\x00\x87\x80\xb7q\x1e\xd0\xeb\x8azSH\x16h\xb5" +
+	"\x97V{\xa1\xa8\xb7\x85\x9e\xb0@\x01\xbc\xadc\x80\xde" +
+	"T\xd4;BO9\x05*\xc0{\xdb\x0f\xe8\xd7\x8a\xfa" +
+	"\xbd\xd0s\xdc\x02\x1d\xc0{7\x0c\xe8mE\xbd'\xf4" +
+	"\\\x16\xe8\x02\xde\xaeu\xee(\xea\x8fB/\xa3\x0a\xcc" +
+	"\x00\xde\x87)@\xef)\xea\xaa0]\x8a\xc2\xc5\x929" +
+	"7\x0b\x80\x1d\x10v\x80il\xae.\x9ar`\xac\xd6" +
+	"\x0ea;\x98\x0dg\xfc\xfa9\x17\xcf\xdd0l\x83\xb0" +
+	"\x0d<\x1a,\x04#\xc3\xf5\xaf\xdc\xac\x9f\xf8\xec\x84\xb0" +
+	"\x13L\x93\xb9\x92\x89\x13\xbf\x04V\xeaw\xffU\xd2\x94" +
+	"\x19\x8f+Q96\xb6\xa7\xb6FO}\xa3\x80\xeeU" +
+	"\xd4\x83\xcd\x9e\x06\xec\xf8'\x14\xf5Y\xe1x\x9c\xf8\xc9" +
+	"bL\x81PZ'g\xcc.pRq?\xb8\xab%" +
+	"X\xfd\x1d<Q,.\x98\xa2\x9f\xccE,\xdb\xec\xff" +
+	"\x1b\xd9\xf7lw\xcb\x8az\xb5\x99}\xdfj+\x8a\xfa" +
+	"a\x0b\xa3\x07v\xa0UE\xbdf\x19\xb1\xc6\xe8\xb1\xa5" +
+	"\xf9HQ\xaf[FRc\xf4\xc4\xae\xb3\xf6\x07\xb1\xab" +
+	"j\x8c\xb6\xfa\x9b\x88se\xbfd\xea\x1cj=7\x8a" +
+	";\xa0\xcc\x03\xe0\x8d\xcf\x84Q0\xdf\xd8\xfe\xbf\xe6\xfb" +
+	"\x00\xad\x98\xab,\x98\xa5:\xa1\xdf\x01\x00\x00\xff\xffJ" +
+	"{\xb8\x95"
 
 func init() {
 	schemas.Register(schema_f4533cbae6e08506,

--- a/seastar/flusher.h
+++ b/seastar/flusher.h
@@ -21,6 +21,7 @@
 #include "packet_cache.h"
 #include "tlog_block.h"
 #include "redis_conn.h"
+#include "connection.h"
 
 /* Erasure encoder */
 class Erasurer {
@@ -135,7 +136,7 @@ public:
 	Flusher(std::string objstor_addr, int objstor_port, std::string priv_key, 
 			int flush_size, int flush_timeout, int k, int m);
 
-	void add_packet(tlog_block *tb, uint32_t vol_id_num);
+	void add_packet(tlog_block *tb, connection *conn);
 
 	future<flush_result*> check_do_flush(uint32_t vol_id);
 	
@@ -158,7 +159,7 @@ private:
 
 	future<bool> get_last_hash(uint32_t vol_id, uint8_t *hash);
 
-	void encodeBlock(tlog_block *tb, TlogBlock::Builder* builder);
+	void encodeBlock(tlog_block *tb, TlogBlock::Builder* builder, std::string& vol_id);
 };
 
 Flusher* get_flusher(shard_id id);

--- a/seastar/main.cc
+++ b/seastar/main.cc
@@ -175,7 +175,7 @@ public:
 
 		return smp::submit_to(conn->_vol_id_num % smp::count, [this, tb, conn] {
 				auto flusher = get_flusher(engine().cpu_id());
-				flusher->add_packet(tb, conn->_vol_id_num);
+				flusher->add_packet(tb, conn);
 				return flusher->check_do_flush(conn->_vol_id_num);
 		}).then([this, conn] (auto fr) {
 			return this->send_response(conn->_out, fr);

--- a/seastar/tlog_block.h
+++ b/seastar/tlog_block.h
@@ -6,7 +6,6 @@
 #include "tlog_schema.capnp.h"
 
 struct tlog_block {
-	std::string _vol_id;
 	uint64_t _sequence;
 	uint64_t _lba;
 	uint32_t _size;
@@ -15,7 +14,6 @@ struct tlog_block {
 	uint64_t _timestamp;
 public:
 	tlog_block(connection *conn, TlogBlock::Builder *block) {
-		_vol_id = conn->_vol_id;
 		_sequence = block->getSequence();
 		_lba = block->getLba();
 		_size = block->getSize();

--- a/tester/get_last_data/main.cc
+++ b/tester/get_last_data/main.cc
@@ -179,7 +179,7 @@ void test_encoded(unsigned char *hash, int hash_len) {
 int main() {
 	// get hash from server
 	int hash_len;
-	std::string hashKey = "last_hash_1234567890";
+	std::string hashKey = "last_hash_12345678901234567890123456789012";
 	unsigned char *hash = get_from_redis(REDIS_ADDR, REDIS_PORT, (const unsigned char *)hashKey.c_str(),
 			hashKey.length(), &hash_len);
 	test_encoded(hash, hash_len);


### PR DESCRIPTION
Planned to remove  tlog_block entirely, so we can use capnp object directly.
But still failed because complicated ownership mechanism in seastar.

This PR still do some optimization by removing  string allocation in tlog_block object.