### PR TITLE
seastar : change to FlatArrayMessageReader.

### DIFF
--- a/seastar/main.cc
+++ b/seastar/main.cc
@@ -155,11 +155,11 @@ public:
 
 	future<> handle_packet(temporary_buffer<char> buf, connection *conn) {
 		// decode the message
-		auto apt = kj::ArrayPtr<kj::byte>((unsigned char *) buf.begin(), buf.size());
-		kj::ArrayInputStream ais(apt);
-		::capnp::MallocMessageBuilder message;
-		readMessageCopy(ais, message);
-		TlogBlock::Builder block = message.getRoot<TlogBlock>();
+		kj::ArrayPtr<const capnp::word> words(
+				reinterpret_cast<const capnp::word*>((unsigned char *) buf.begin()),
+				buf.size() / sizeof(capnp::word));
+		::capnp::FlatArrayMessageReader famr(words);
+		TlogBlock::Reader block = famr.getRoot<TlogBlock>();
 
 		conn->set_vol_id(block.getVolumeId().cStr(), block.getVolumeId().size());
 

--- a/seastar/tlog_block.h
+++ b/seastar/tlog_block.h
@@ -13,7 +13,7 @@ struct tlog_block {
 	uint8_t *_data;
 	uint64_t _timestamp;
 public:
-	tlog_block(connection *conn, TlogBlock::Builder *block) {
+	tlog_block(connection *conn, TlogBlock::Reader *block) {
 		_sequence = block->getSequence();
 		_lba = block->getLba();
 		_size = block->getSize();


### PR DESCRIPTION
Fixes #58 by using FlatArrayMessageBuilder to avoid copying.
for 2500 messages:
- old version = 19 seconds
- this version = 17.2 seconds